### PR TITLE
feat(permissions): expose history reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Added separate Health Connect history-read and background-read authorization methods. Metric authorization remains independent of both optional permissions.
+* Temporarily pinned the Android dependency to the matching fork commit pending upstream Android SDK PR #21.
+
 ## 0.0.20
 
 * Bumped native iOS SDK dependency from `~> 0.12.0` to `~> 0.13.0`.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ final authorized = await OpenWearablesHealthSdk.requestAuthorization(
     HealthDataType.workout,
   ],
 );
+
+// Health Connect only: request optional access separately.
+// Foreground/manual sync still works if either request returns false.
+final historyAuthorized =
+    await OpenWearablesHealthSdk.requestHistoryReadAuthorization();
+final backgroundAuthorized =
+    await OpenWearablesHealthSdk.requestBackgroundReadAuthorization();
 ```
 
 ### 5. Start Background Sync

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,9 @@ android {
     }
 
     dependencies {
-        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.10.0")
+        // Temporary fork pin for the history/background permission API.
+        // Replace with the upstream release that includes open_wearables_android_sdk#21.
+        implementation("com.github.y3l1n4ung.open_wearables_android_sdk:sdk:93953bf2710cc7c01103d6c03dda67c076be84dd")
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/android/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSdkPlugin.kt
+++ b/android/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSdkPlugin.kt
@@ -167,6 +167,12 @@ class OpenWearablesHealthSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             "updateTokens" -> handleUpdateTokens(s, call, result)
             "getStoredCredentials" -> result.success(s.getStoredCredentials())
             "requestAuthorization" -> handleRequestAuthorization(s, call, result)
+            "requestBackgroundReadAuthorization" -> handleOptionalAuthorization(result) {
+                s.requestBackgroundReadAuthorization()
+            }
+            "requestHistoryReadAuthorization" -> handleOptionalAuthorization(result) {
+                s.requestHistoryReadAuthorization()
+            }
             "startBackgroundSync" -> handleStartBackgroundSync(s, call, result)
             "stopBackgroundSync" -> handleStopBackgroundSync(s, result)
             "syncNow" -> handleSyncNow(s, result)
@@ -243,6 +249,16 @@ class OpenWearablesHealthSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             try {
                 val authorized = sdk.requestAuthorization(types)
                 result.success(authorized)
+            } catch (e: Exception) {
+                result.error("auth_failed", e.message, null)
+            }
+        }
+    }
+
+    private fun handleOptionalAuthorization(result: Result, request: suspend () -> Boolean) {
+        scope.launch {
+            try {
+                result.success(request())
             } catch (e: Exception) {
                 result.error("auth_failed", e.message, null)
             }

--- a/ios/Classes/OpenWearablesHealthSdkPlugin.swift
+++ b/ios/Classes/OpenWearablesHealthSdkPlugin.swift
@@ -132,6 +132,10 @@ public class OpenWearablesHealthSdkPlugin: NSObject, FlutterPlugin, FlutterStrea
                 result(ok)
             }
 
+        case "requestBackgroundReadAuthorization", "requestHistoryReadAuthorization":
+            // These are Health Connect-specific optional permissions.
+            result(false)
+
         case "syncNow":
             sdk.syncNow { result(nil) }
 

--- a/lib/open_wearables_health_sdk.dart
+++ b/lib/open_wearables_health_sdk.dart
@@ -23,7 +23,8 @@ export 'open_wearables_health_sdk_method_channel.dart';
 /// Ensure MethodChannel is the default implementation.
 /// This runs at library load time before any static methods can be called.
 final OpenWearablesHealthSdkPlatform _platform = (() {
-  OpenWearablesHealthSdkPlatform.instance = MethodChannelOpenWearablesHealthSdk();
+  OpenWearablesHealthSdkPlatform.instance =
+      MethodChannelOpenWearablesHealthSdk();
   return OpenWearablesHealthSdkPlatform.instance;
 })();
 
@@ -87,9 +88,7 @@ class OpenWearablesHealthSdk {
   ///   print('Welcome back!');
   /// }
   /// ```
-  static Future<void> configure({
-    required String host,
-  }) async {
+  static Future<void> configure({required String host}) async {
     _config = OpenWearablesHealthSdkConfig(host: host);
 
     _updateLogSubscription();
@@ -181,7 +180,9 @@ class OpenWearablesHealthSdk {
     final hasApiKey = apiKey != null;
 
     if (!hasTokens && !hasApiKey) {
-      throw ArgumentError('You must provide either (accessToken + refreshToken) or (apiKey).');
+      throw ArgumentError(
+        'You must provide either (accessToken + refreshToken) or (apiKey).',
+      );
     }
 
     await _platform.signIn(
@@ -262,9 +263,33 @@ class OpenWearablesHealthSdk {
   /// Returns true if authorization was successful, false otherwise.
   ///
   /// Throws [NotSignedInException] if no user is signed in.
-  static Future<bool> requestAuthorization({required List<HealthDataType> types}) async {
+  static Future<bool> requestAuthorization({
+    required List<HealthDataType> types,
+  }) async {
     _ensureSignedIn();
-    return _platform.requestAuthorization(types: types.map((e) => e.id).toList(growable: false));
+    return _platform.requestAuthorization(
+      types: types.map((e) => e.id).toList(growable: false),
+    );
+  }
+
+  /// Requests optional Health Connect background-read access on Android.
+  ///
+  /// Call this separately after metric authorization. A `false` result means
+  /// the permission is unavailable or denied; foreground/manual sync remains usable.
+  /// Returns `false` on iOS and for Android providers without this permission.
+  static Future<bool> requestBackgroundReadAuthorization() async {
+    _ensureSignedIn();
+    return _platform.requestBackgroundReadAuthorization();
+  }
+
+  /// Requests optional access to Health Connect data older than its default window.
+  ///
+  /// Call this separately before importing extended history. A `false` result means
+  /// the permission is unavailable or denied; the default history window remains usable.
+  /// Returns `false` on iOS and for Android providers without this permission.
+  static Future<bool> requestHistoryReadAuthorization() async {
+    _ensureSignedIn();
+    return _platform.requestHistoryReadAuthorization();
   }
 
   // MARK: - Sync Operations
@@ -299,7 +324,9 @@ class OpenWearablesHealthSdk {
   /// ```
   static Future<bool> startBackgroundSync({int? syncDaysBack}) async {
     _ensureSignedIn();
-    final started = await _platform.startBackgroundSync(syncDaysBack: syncDaysBack);
+    final started = await _platform.startBackgroundSync(
+      syncDaysBack: syncDaysBack,
+    );
     if (started) {
       _isSyncActive = true;
     }

--- a/lib/open_wearables_health_sdk_method_channel.dart
+++ b/lib/open_wearables_health_sdk_method_channel.dart
@@ -6,13 +6,21 @@ import 'open_wearables_health_sdk_platform_interface.dart';
 import 'src/exceptions.dart';
 
 /// MethodChannel-based implementation of the OpenWearablesHealthSdk platform interface.
-class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform {
-  static const MethodChannel _channel = MethodChannel('open_wearables_health_sdk');
-  static const EventChannel _logChannel = EventChannel('open_wearables_health_sdk/logs');
-  static const EventChannel _authErrorChannel = EventChannel('open_wearables_health_sdk/auth_errors');
+class MethodChannelOpenWearablesHealthSdk
+    extends OpenWearablesHealthSdkPlatform {
+  static const MethodChannel _channel = MethodChannel(
+    'open_wearables_health_sdk',
+  );
+  static const EventChannel _logChannel = EventChannel(
+    'open_wearables_health_sdk/logs',
+  );
+  static const EventChannel _authErrorChannel = EventChannel(
+    'open_wearables_health_sdk/auth_errors',
+  );
 
   static final StreamController<String> _logController = _createLogController();
-  static final StreamController<Map<String, dynamic>> _authErrorController = _createAuthErrorController();
+  static final StreamController<Map<String, dynamic>> _authErrorController =
+      _createAuthErrorController();
 
   static StreamController<String> _createLogController() {
     final controller = StreamController<String>.broadcast();
@@ -25,16 +33,13 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
 
   static StreamController<Map<String, dynamic>> _createAuthErrorController() {
     final controller = StreamController<Map<String, dynamic>>.broadcast();
-    _authErrorChannel.receiveBroadcastStream().listen(
-      (event) {
-        if (event is Map) {
-          controller.add(Map<String, dynamic>.from(event));
-        } else {
-          controller.add({'statusCode': 401, 'message': 'Authentication error'});
-        }
-      },
-      onError: (error) => controller.addError(error),
-    );
+    _authErrorChannel.receiveBroadcastStream().listen((event) {
+      if (event is Map) {
+        controller.add(Map<String, dynamic>.from(event));
+      } else {
+        controller.add({'statusCode': 401, 'message': 'Authentication error'});
+      }
+    }, onError: (error) => controller.addError(error));
     return controller;
   }
 
@@ -44,13 +49,12 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
 
   /// Stream of authentication errors (e.g., 401 Unauthorized).
   /// Multiple listeners can subscribe simultaneously.
-  static Stream<Map<String, dynamic>> get authErrorStream => _authErrorController.stream;
+  static Stream<Map<String, dynamic>> get authErrorStream =>
+      _authErrorController.stream;
 
   @override
   Future<bool> configure({required String host}) async {
-    await _channel.invokeMethod<void>('configure', {
-      'host': host,
-    });
+    await _channel.invokeMethod<void>('configure', {'host': host});
 
     // Check if sync was auto-restored by querying isSyncActive
     final isSyncActive = await _channel.invokeMethod<bool>('isSyncActive');
@@ -72,7 +76,10 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
         if (apiKey != null) 'apiKey': apiKey,
       });
     } on PlatformException catch (e) {
-      throw SignInException(e.message ?? 'Sign-in failed', statusCode: int.tryParse(e.code));
+      throw SignInException(
+        e.message ?? 'Sign-in failed',
+        statusCode: int.tryParse(e.code),
+      );
     }
   }
 
@@ -100,7 +107,25 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
 
   @override
   Future<bool> requestAuthorization({required List<String> types}) async {
-    final result = await _channel.invokeMethod<bool>('requestAuthorization', {'types': types});
+    final result = await _channel.invokeMethod<bool>('requestAuthorization', {
+      'types': types,
+    });
+    return result == true;
+  }
+
+  @override
+  Future<bool> requestBackgroundReadAuthorization() async {
+    final result = await _channel.invokeMethod<bool>(
+      'requestBackgroundReadAuthorization',
+    );
+    return result == true;
+  }
+
+  @override
+  Future<bool> requestHistoryReadAuthorization() async {
+    final result = await _channel.invokeMethod<bool>(
+      'requestHistoryReadAuthorization',
+    );
     return result == true;
   }
 
@@ -129,14 +154,18 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
 
   @override
   Future<Map<String, dynamic>> getStoredCredentials() async {
-    final result = await _channel.invokeMethod<Map<Object?, Object?>>('getStoredCredentials');
+    final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+      'getStoredCredentials',
+    );
     if (result == null) return {};
     return result.map((key, value) => MapEntry(key as String, value));
   }
 
   @override
   Future<Map<String, dynamic>> getSyncStatus() async {
-    final result = await _channel.invokeMethod<Map<Object?, Object?>>('getSyncStatus');
+    final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+      'getSyncStatus',
+    );
     if (result == null) return {};
     return result.map((key, value) => MapEntry(key as String, value));
   }
@@ -153,14 +182,14 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
 
   @override
   Future<void> setProvider({required String providerId}) async {
-    await _channel.invokeMethod<void>('setProvider', {
-      'provider': providerId,
-    });
+    await _channel.invokeMethod<void>('setProvider', {'provider': providerId});
   }
 
   @override
   Future<List<Map<String, dynamic>>> getAvailableProviders() async {
-    final result = await _channel.invokeMethod<List<Object?>>('getAvailableProviders');
+    final result = await _channel.invokeMethod<List<Object?>>(
+      'getAvailableProviders',
+    );
     if (result == null) return [];
     return result
         .whereType<Map<Object?, Object?>>()

--- a/lib/open_wearables_health_sdk_platform_interface.dart
+++ b/lib/open_wearables_health_sdk_platform_interface.dart
@@ -6,7 +6,8 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static OpenWearablesHealthSdkPlatform _instance = _NoopOpenWearablesHealthSdkPlatform();
+  static OpenWearablesHealthSdkPlatform _instance =
+      _NoopOpenWearablesHealthSdkPlatform();
 
   static OpenWearablesHealthSdkPlatform get instance => _instance;
 
@@ -75,7 +76,25 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
 
   /// Requests authorization from HealthKit/Health Connect.
   Future<bool> requestAuthorization({required List<String> types}) {
-    throw UnimplementedError('requestAuthorization() has not been implemented.');
+    throw UnimplementedError(
+      'requestAuthorization() has not been implemented.',
+    );
+  }
+
+  /// Requests optional Android access to health data while the app is in the background.
+  /// Returns false on platforms or providers that do not expose this permission.
+  Future<bool> requestBackgroundReadAuthorization() {
+    throw UnimplementedError(
+      'requestBackgroundReadAuthorization() has not been implemented.',
+    );
+  }
+
+  /// Requests optional Android access to data older than Health Connect's default window.
+  /// Returns false on platforms or providers that do not expose this permission.
+  Future<bool> requestHistoryReadAuthorization() {
+    throw UnimplementedError(
+      'requestHistoryReadAuthorization() has not been implemented.',
+    );
   }
 
   // MARK: - Sync Operations
@@ -101,7 +120,9 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
 
   /// Returns stored credentials for debugging/display purposes.
   Future<Map<String, dynamic>> getStoredCredentials() {
-    throw UnimplementedError('getStoredCredentials() has not been implemented.');
+    throw UnimplementedError(
+      'getStoredCredentials() has not been implemented.',
+    );
   }
 
   /// Returns the current sync session status.
@@ -143,7 +164,9 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
   /// On iOS, this always returns an empty list (HealthKit is implicit).
   /// On Android, returns providers that are installed and meet requirements.
   Future<List<Map<String, dynamic>>> getAvailableProviders() {
-    throw UnimplementedError('getAvailableProviders() has not been implemented.');
+    throw UnimplementedError(
+      'getAvailableProviders() has not been implemented.',
+    );
   }
 
   // MARK: - Notification
@@ -168,4 +191,5 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
 }
 
 /// NO-OP placeholder.
-class _NoopOpenWearablesHealthSdkPlatform extends OpenWearablesHealthSdkPlatform {}
+class _NoopOpenWearablesHealthSdkPlatform
+    extends OpenWearablesHealthSdkPlatform {}

--- a/test/open_wearables_health_sdk_method_channel_test.dart
+++ b/test/open_wearables_health_sdk_method_channel_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:open_wearables_health_sdk/open_wearables_health_sdk_method_channel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('open_wearables_health_sdk');
+  final platform = MethodChannelOpenWearablesHealthSdk();
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('returns true when history access is granted', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'requestHistoryReadAuthorization');
+          return true;
+        });
+
+    expect(await platform.requestHistoryReadAuthorization(), isTrue);
+  });
+
+  test('returns false when history access is denied', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'requestHistoryReadAuthorization');
+          return false;
+        });
+
+    expect(await platform.requestHistoryReadAuthorization(), isFalse);
+  });
+
+  test('returns false when background access is denied', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'requestBackgroundReadAuthorization');
+          return false;
+        });
+
+    expect(await platform.requestBackgroundReadAuthorization(), isFalse);
+  });
+
+  test('returns true when background access is granted', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'requestBackgroundReadAuthorization');
+          return true;
+        });
+
+    expect(await platform.requestBackgroundReadAuthorization(), isTrue);
+  });
+}


### PR DESCRIPTION
## Description

Expose Health Connect history and background read authorization as separate optional Flutter APIs. Metric authorization remains usable when either optional permission is unavailable or denied.

## Changes

- Add Dart platform and method-channel APIs for optional history/background access.
- Bridge both methods to Android SDK PR #21.
- Return `false` on iOS because these permissions are Health Connect-specific.
- Cover granted and denied method-channel results.

## Validation

- `flutter analyze`
- `flutter test test/open_wearables_health_sdk_method_channel_test.dart`
- Android bridge `compileDebugKotlin` against Android commit `93953bf2710cc7c01103d6c03dda67c076be84dd`
- `git diff --check`

Depends on: https://github.com/the-momentum/open_wearables_android_sdk/pull/21
Related: https://github.com/y3l1n4ung/ovarian_longevity_app/issues/174